### PR TITLE
Changed time of enabling output

### DIFF
--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.c
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.c
@@ -105,10 +105,10 @@ void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
   uint8_t curbyte,ctr,masklo;
   uint8_t sreg_prev;
   
+  ws2812_DDRREG |= maskhi; // Enable output
+  
   masklo	=~maskhi&ws2812_PORTREG;
   maskhi |=        ws2812_PORTREG;
-  
-  ws2812_DDRREG |= maskhi; // Enable output
   
   sreg_prev=SREG;
   cli();  


### PR DESCRIPTION
Make sure that set ws2812_DDRREG just enables the selected (param maskhi) output.