### PR TITLE
feature: platformio support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ light_ws2812\Objects\*
 *.app
 
 .DS_Store
+.pioenvs/
+.piolibdeps/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+sudo: false
+cache:
+  directories:
+    - "~/.platformio"
+install:
+  - pip install -U platformio
+  - pio update
+
+script:
+  - for i in `echo examples/*`; do (cd "${i}" && pio run); done

--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ Usage C++ - Interface
 - Refer to the header WS2812.h to determine how to use the class.
 - Ports and LED-Count are handled dynamically, so you can add as many LED-Strips as you got free outpupt ports! 
 
+Usage `platformio`
+==================
+
+For `arduino` and pure C implementations, the library supports `platformio`.
+By default, `light_ws2812_Arduino` will be used. If `arduino` is not used,
+i.e. the code is written pure C without `arduino`, define one of `build_flags`
+in `platformio.ini`.
+
+| Flag               | Library            |
+|--------------------|--------------------|
+| `LIGHT_WS2812_AVR` | `light_ws2812_AVR` |
+| `LIGHT_APA102_AVR` | `light_apa102_AVR` |
+
+Here is an example `platformio.ini` for `attiny85` without `arduino`.
+
+```ini
+[env:attiny85]
+board = attiny85
+platform = atmelavr
+lib_deps = https://github.com/cpldcpu/light_ws2812.git
+build_flags = -DLIGHT_WS2812_AVR
+```
+
+All examples under [examples](examples) directory are built by `platformio`.
 
 Troubleshooting 
 ================

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Usage C - Interface
 ===================
 
 - Add "light_ws2812.c", "light_ws2812.h" and "ws2812_config.h" to your project. 
-- Update "ws2812_config.h" according to your I/O pin.
+- Optionally update `ws2812_config.h` according to your I/O pin, and include it before
+  including `light_ws2812.h`. Otherwise, the defaults in `light_ws2812.h` will
+  be used.
 - Make sure F\_CPU is correctly defined in your makefile or the project. (For AtmelStudio: Project->Properties->Toolchain->AVR/GNU C Compiler->Symbols. Add symbol F_CPU=xxxxx)
 - Call "ws2812\_setleds" with a pointer to the LED array and the number LEDs.
 - Alternatively you can use "ws2812\_setleds\_pin" to control up to 8 LED strips on the same Port.

--- a/examples/apa102_avr_RBG_blinky/platformio.ini
+++ b/examples/apa102_avr_RBG_blinky/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+build_flags = -DLIGHT_APA102_AVR
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+
+[env:attiny85]
+board = attiny85
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+
+# with ArduinoISP programmer
+upload_port = ${common.upload_port}
+upload_speed = 9600
+upload_protocol = stk500v1
+upload_flags =
+    -P$UPLOAD_PORT
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+upload_port = ${common.upload_port}

--- a/examples/apa102_avr_RBG_blinky/src/RGB_blinky.c
+++ b/examples/apa102_avr_RBG_blinky/src/RGB_blinky.c
@@ -1,0 +1,1 @@
+../../../light_apa102_AVR/Examples/RGB_blinky.c

--- a/examples/ws2812_arduino_Blinky/platformio.ini
+++ b/examples/ws2812_arduino_Blinky/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+framework = arduino
+
+[env:attiny85]
+board = attiny85
+platform = ${common.platform}
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+
+# with ArduinoISP programmer
+upload_port = ${common.upload_port}
+upload_speed = 9600
+upload_protocol = stk500v1
+upload_flags =
+    -P$UPLOAD_PORT
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+upload_port = ${common.upload_port}

--- a/examples/ws2812_arduino_Blinky/src
+++ b/examples/ws2812_arduino_Blinky/src
@@ -1,0 +1,1 @@
+../../light_ws2812_Arduino/light_WS2812/examples/Blinky

--- a/examples/ws2812_arduino_RGB_Clock/platformio.ini
+++ b/examples/ws2812_arduino_RGB_Clock/platformio.ini
@@ -1,0 +1,15 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+framework = arduino
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+upload_port = ${common.upload_port}

--- a/examples/ws2812_arduino_RGB_Clock/src
+++ b/examples/ws2812_arduino_RGB_Clock/src
@@ -1,0 +1,1 @@
+../../light_ws2812_Arduino/light_WS2812/examples/RGB_Clock

--- a/examples/ws2812_arduino_fade_rgb/platformio.ini
+++ b/examples/ws2812_arduino_fade_rgb/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+framework = arduino
+
+[env:attiny85]
+board = attiny85
+platform = ${common.platform}
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+
+# with ArduinoISP programmer
+upload_port = ${common.upload_port}
+upload_speed = 9600
+upload_protocol = stk500v1
+upload_flags =
+    -P$UPLOAD_PORT
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+upload_port = ${common.upload_port}

--- a/examples/ws2812_arduino_fade_rgb/src
+++ b/examples/ws2812_arduino_fade_rgb/src
@@ -1,0 +1,1 @@
+../../light_ws2812_Arduino/light_WS2812/examples/fade_rgb

--- a/examples/ws2812_arduino_rainbow/platformio.ini
+++ b/examples/ws2812_arduino_rainbow/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+framework = arduino
+
+[env:attiny85]
+board = attiny85
+platform = ${common.platform}
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+
+# with ArduinoISP programmer
+upload_port = ${common.upload_port}
+upload_speed = 9600
+upload_protocol = stk500v1
+upload_flags =
+    -P$UPLOAD_PORT
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+upload_port = ${common.upload_port}

--- a/examples/ws2812_arduino_rainbow/src
+++ b/examples/ws2812_arduino_rainbow/src
@@ -1,0 +1,1 @@
+../../light_ws2812_Arduino/light_WS2812/examples/rainbow

--- a/examples/ws2812_avr_Chained_writes/platformio.ini
+++ b/examples/ws2812_avr_Chained_writes/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+build_flags = -DLIGHT_WS2812_AVR
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+
+[env:attiny85]
+board = attiny85
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+
+# with ArduinoISP programmer
+upload_port = ${common.upload_port}
+upload_speed = 9600
+upload_protocol = stk500v1
+upload_flags =
+    -P$UPLOAD_PORT
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+upload_port = ${common.upload_port}

--- a/examples/ws2812_avr_Chained_writes/src/Chained_writes.c
+++ b/examples/ws2812_avr_Chained_writes/src/Chained_writes.c
@@ -1,0 +1,1 @@
+../../../light_ws2812_AVR/Examples/Chained_writes.c

--- a/examples/ws2812_avr_RGBW_blinky/platformio.ini
+++ b/examples/ws2812_avr_RGBW_blinky/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+build_flags = -DLIGHT_WS2812_AVR
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+
+[env:attiny85]
+board = attiny85
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+
+# with ArduinoISP programmer
+upload_port = ${common.upload_port}
+upload_speed = 9600
+upload_protocol = stk500v1
+upload_flags =
+    -P$UPLOAD_PORT
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+upload_port = ${common.upload_port}

--- a/examples/ws2812_avr_RGBW_blinky/src/RGBW_blinky.c
+++ b/examples/ws2812_avr_RGBW_blinky/src/RGBW_blinky.c
@@ -1,0 +1,1 @@
+../../../light_ws2812_AVR/Examples/RGBW_blinky.c

--- a/examples/ws2812_avr_RGB_blinky/platformio.ini
+++ b/examples/ws2812_avr_RGB_blinky/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+build_flags = -DLIGHT_WS2812_AVR
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+
+[env:attiny85]
+board = attiny85
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+
+# with ArduinoISP programmer
+upload_port = ${common.upload_port}
+upload_speed = 9600
+upload_protocol = stk500v1
+upload_flags =
+    -P$UPLOAD_PORT
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+upload_port = ${common.upload_port}

--- a/examples/ws2812_avr_RGB_blinky/src/RGB_blinky.c
+++ b/examples/ws2812_avr_RGB_blinky/src/RGB_blinky.c
@@ -1,0 +1,1 @@
+../../../light_ws2812_AVR/Examples/RGB_blinky.c

--- a/examples/ws2812_avr_rainbow/platformio.ini
+++ b/examples/ws2812_avr_rainbow/platformio.ini
@@ -1,0 +1,28 @@
+[platformio]
+lib_dir = ../../../
+
+[common]
+platform = atmelavr
+build_flags = -DLIGHT_WS2812_AVR
+lib_deps = light_ws2812
+upload_port = /dev/cuaU0
+
+[env:attiny85]
+board = attiny85
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+
+# with ArduinoISP programmer
+upload_port = ${common.upload_port}
+upload_speed = 9600
+upload_protocol = stk500v1
+upload_flags =
+    -P$UPLOAD_PORT
+
+[env:nanoatmega328]
+board = nanoatmega328
+platform = ${common.platform}
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+upload_port = ${common.upload_port}

--- a/examples/ws2812_avr_rainbow/src/Rainbow.c
+++ b/examples/ws2812_avr_rainbow/src/Rainbow.c
@@ -1,0 +1,1 @@
+../../../light_ws2812_AVR/Examples/Rainbow.c

--- a/library.json
+++ b/library.json
@@ -1,0 +1,34 @@
+{
+    "name": "light_ws2812",
+    "description": "Light weight library to control WS2811/WS2812 based LEDS and LED Strings for 8-Bit AVR microcontrollers",
+    "keywords": "neopixel,ws2811,ws2812,apa102,attiny,avr",
+    "authors": {
+        "name": "cpldcpu",
+        "email": "cpldcpu@gmail.com",
+        "url": "https://github.com/cpldcpu",
+        "maintainer": true
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/cpldcpu/light_ws2812.git"
+    },
+    "license": "GPL-3.0-only",
+    "export": {
+        "exclude": [ "Datasheets" ]
+    },
+    "frameworks": [
+        "arduino"
+    ],
+    "platforms": [
+        "atmelavr"
+    ],
+    "build": {
+        "extraScript": "prebuild.py"
+    },
+    "dependencies": [
+    ],
+    "examples": [
+        "examples/*/src/*.ino",
+        "examples/*/src/*.c"
+    ]
+}

--- a/light_apa102_AVR/Light_apa102/light_apa102.h
+++ b/light_apa102_AVR/Light_apa102/light_apa102.h
@@ -14,7 +14,33 @@
 
 #include <avr/io.h>
 #include <avr/interrupt.h>
-#include "apa102_config.h"
+
+///////////////////////////////////////////////////////////////////////
+// Define I/O pins
+// Clk and Data have to be connected to the same port
+///////////////////////////////////////////////////////////////////////
+
+#if !defined(apa102_port)
+#define apa102_port B     // Data and clk port
+#endif
+#if !defined(apa102_data)
+#define apa102_data 0    // Data out pin
+#endif
+#if !defined(apa102_clk)
+#define apa102_clk  2    // Clk out pin
+#endif
+
+///////////////////////////////////////////////////////////////////////
+// Define color byte order
+//
+// Define APA102_BYTE_ORDER_GBR if byte order is not standard BGR.
+///////////////////////////////////////////////////////////////////////
+
+#if defined(APA102_BYTE_ORDER_GBR)
+struct cRGB { uint8_t g; uint8_t b; uint8_t r; };   // GBR
+#else
+struct cRGB { uint8_t b; uint8_t g; uint8_t r; };   // BGR (APA102 Standard)
+#endif
 
 /* User Interface
  * 

--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.h
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.h
@@ -15,7 +15,30 @@
 
 #include <avr/io.h>
 #include <avr/interrupt.h>
-#include "ws2812_config.h"
+
+///////////////////////////////////////////////////////////////////////
+// Define Reset time in µs.
+//
+// This is the time the library spends waiting after writing the data.
+//
+// WS2813 needs 300 µs reset time
+// WS2812 and clones only need 50 µs
+//
+///////////////////////////////////////////////////////////////////////
+#if !defined(ws2812_resettime)
+#define ws2812_resettime    300
+#endif
+
+///////////////////////////////////////////////////////////////////////
+// Define I/O pin
+///////////////////////////////////////////////////////////////////////
+#if !defined(ws2812_port)
+#define ws2812_port B   // Data port
+#endif
+
+#if !defined(ws2812_pin)
+#define ws2812_pin  2   // Data out pin
+#endif
 
 /*
  *  Structure of the LED array

--- a/prebuild.py
+++ b/prebuild.py
@@ -1,0 +1,34 @@
+import os
+Import("env")
+
+# XXX __file__ does not work here.
+dir_path = Dir('.').abspath
+src_filter = []
+env.Replace(SRC_FILTER=src_filter)
+src_defined = False
+
+if 'BUILD_FLAGS' in env:
+    build_flags = env.ParseFlags(env['BUILD_FLAGS'])
+    cppdefines = build_flags.get("CPPDEFINES")
+
+    if "LIGHT_WS2812_AVR" in cppdefines:
+        # pure C without arduino
+        env.Append(SRC_FILTER=["+<light_ws2812_AVR/Light_WS2812/*.c>", "light_ws2812_AVR/Light_WS2812/*.h"])
+        # there is no way to change src_dir. without the following, the compiler
+        # would look for the header files in root directory of the library.
+        env.Append(CPPPATH=[
+            os.path.join(dir_path, "light_ws2812_AVR", "Light_WS2812")
+            ])
+        src_defined = True
+    elif "LIGHT_APA102_AVR" in cppdefines:
+        env.Append(SRC_FILTER=["+<light_apa102_AVR/Light_apa102/*.c>", "light_apa102_AVR/Light_apa102/*.h"])
+        env.Append(CPPPATH=[
+            os.path.join(dir_path, "light_apa102_AVR", "Light_apa102")
+            ])
+        src_defined = True
+if not src_defined:
+    # defaults to arduino
+    env.Append(SRC_FILTER=["+<light_ws2812_Arduino/light_WS2812/*>"])
+    env.Append(CPPPATH=[
+        os.path.join(dir_path, "light_ws2812_Arduino", "light_WS2812")
+        ])


### PR DESCRIPTION
all examples for `atmelavr` and `arduino`, platforms that are supported by `platromio`, are built with `platformio`. 

this PR also make `*_config.h` optional. users simply overrides `define`s in the application code, other header files, or `make -D`.