### PR TITLE
Allow interrupts between the transmission of bytes

### DIFF
--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.c
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.c
@@ -111,10 +111,11 @@ void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
   maskhi |=        ws2812_PORTREG;
   
   sreg_prev=SREG;
-  cli();  
 
   while (datlen--) {
+    SREG=sreg_prev;
     curbyte=*data++;
+    cli();
     
     asm volatile(
     "       ldi   %0,8  \n\t"

--- a/light_ws2812_Arduino/light_WS2812/light_ws2812.cpp
+++ b/light_ws2812_Arduino/light_WS2812/light_ws2812.cpp
@@ -82,10 +82,11 @@ void  WS2812::ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi
   masklo = ~maskhi & *port;
   maskhi |= *port;
   sreg_prev=SREG;
-  cli();  
 
   while (datlen--) {
+    SREG=sreg_prev;
     curbyte=*data++;
+    cli();
     
     asm volatile(
     "       ldi   %0,8  \n\t"


### PR DESCRIPTION
I wanted to give my animations constant framerates and for that I need to use the timer interrupt. Since the maximum prescaler on my microcontroller is 1024, I must trigger the interrupt at least every 4ms, with a 16bit timer and F_CPU=16Mhz.

A call of `ws2812_setleds_rgbw()` takes ca. 12ms for a 5m LED strip with 60LEDs/m. Thus interrupts need to be handled during the data transmission.

With my SK6812 RGBW LED strip I found, that I can add a delay of up to 30µs between the transmission of each byte, without problems. This should be plenty of time for normal interrupt handling.