### PR TITLE
Prevent CONCAT() redefinition warning

### DIFF
--- a/light_apa102_AVR/Light_apa102/light_apa102.h
+++ b/light_apa102_AVR/Light_apa102/light_apa102.h
@@ -60,8 +60,13 @@ void apa102_setleds_brightness    (struct cRGB *ledarray, uint16_t number_of_led
 /*
  * Internal defines
  */
+#if !defined(CONCAT)
 #define CONCAT(a, b)            a ## b
+#endif
+
+#if !defined(CONCAT_EXP)
 #define CONCAT_EXP(a, b)   CONCAT(a, b)
+#endif
 
 #define apa102_PORTREG  CONCAT_EXP(PORT,apa102_port)
 #define apa102_DDRREG   CONCAT_EXP(DDR,apa102_port)

--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.h
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.h
@@ -83,9 +83,13 @@ void ws2812_sendarray_mask(uint8_t *array,uint16_t length, uint8_t pinmask);
 /*
  * Internal defines
  */
-
+#if !defined(CONCAT)
 #define CONCAT(a, b)            a ## b
+#endif
+
+#if !defined(CONCAT_EXP)
 #define CONCAT_EXP(a, b)   CONCAT(a, b)
+#endif
 
 #define ws2812_PORTREG  CONCAT_EXP(PORT,ws2812_port)
 #define ws2812_DDRREG   CONCAT_EXP(DDR,ws2812_port)


### PR DESCRIPTION
When using this library in a LUFA project, the `CONCAT()` define generates a warning as it has already been defined (but with arguments `x` and `y` instead of `a` and `b`).