### PR TITLE
ARM Freescale support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ Tested Combinations Arduino
 
 Tested Combinations ARM
 ================
-| Device             | 8 MHz | 16 MHz |  12 MHz  | 20 MHz  | 30 MHz | 
-| -------------      |:-------:|:-------:|:-------:|:-----:|:------:|
-| LPC810 (Cortex M0+)|         |         |  X      |   X   |  X     |    
-| STM32F0 (Cortex M0+)| X      |         |         |       |        |    
-| STM32L0 (Cortex M0+)| X      |  X      |         |       |        |    
+|         Device         | 12 MHz | 16 MHz | 20 MHz | 30 MHz | 32 MHz |
+|:----------------------:|:------:|:------:|:------:|:------:|--------|
+|   LPC810 (Cortex M0+)  |    X   |        |    X   |    X   |        |
+| STL32L052 (Cortex M0+) |        |    X   |        |        |        |
+|   KW36Z (Cortex M0+)   |        |        |        |        | X      |   
 
 Please find updates on https://github.com/cpldcpu/light_ws2812
 

--- a/light_ws2812_ARM/README.md
+++ b/light_ws2812_ARM/README.md
@@ -38,10 +38,11 @@ Release History
 
 Tested Combinations ARM
 ================
-| Device             | 12 MHz  | 16 MHz  | 20 MHz  | 30 MHz | 
-| -------------      |:-------:| :-----: | :-----: | :------: |
-| LPC810 (Cortex M0+)| X       |         |    X    |    X   |
-| STL32L052 (Cortex M0+)|      |  X      |         |        |
+| Device             | 12 MHz  | 16 MHz  | 20 MHz  | 30 MHz | 32 MHz | 
+| -------------      |:-------:| :-----: | :-----: | :------: :------:
+| LPC810 (Cortex M0+)| X       |         |    X    |    X   |        |
+| STL32L052 (Cortex M0+)|      |  X      |         |        |        | 
+| KW36Z (Cortex M0+)|          |         |         |        |    X   | 
 
 Please find updates on https://github.com/cpldcpu/light_ws2812
 

--- a/light_ws2812_ARM/README.md
+++ b/light_ws2812_ARM/README.md
@@ -38,11 +38,11 @@ Release History
 
 Tested Combinations ARM
 ================
-| Device             | 12 MHz  | 16 MHz  | 20 MHz  | 30 MHz | 32 MHz | 
-| -------------      |:-------:| :-----: | :-----: | :------: :------:
-| LPC810 (Cortex M0+)| X       |         |    X    |    X   |        |
-| STL32L052 (Cortex M0+)|      |  X      |         |        |        | 
-| KW36Z (Cortex M0+)|          |         |         |        |    X   | 
+|         Device         | 12 MHz | 16 MHz | 20 MHz | 30 MHz | 32 MHz |
+|:----------------------:|:------:|:------:|:------:|:------:|--------|
+|   LPC810 (Cortex M0+)  |    X   |        |    X   |    X   |        |
+| STL32L052 (Cortex M0+) |        |    X   |        |        |        |
+|   KW36Z (Cortex M0+)   |        |        |        |        | X      |
 
 Please find updates on https://github.com/cpldcpu/light_ws2812
 

--- a/light_ws2812_ARM/light_ws2812_cortex.h
+++ b/light_ws2812_ARM/light_ws2812_cortex.h
@@ -22,6 +22,10 @@
 #elif defined(LIGHT_WS2812_UC_STM32L0XX)
   #include "stm32l0xx_hal.h"
   #define LIGHT_WS2812_STM32
+#elif defined(LIGHT_WS2812_UC_FSL)
+#include "fsl_port.h"
+#include "fsl_gpio.h"
+#define LIGHT_WS2812_FSL
 #else
 #error "Error: Please define WS2812_UC_XXXXX"
 #endif
@@ -48,6 +52,14 @@
 
   #define ws2812_mask_set  LIGHT_WS2812_GPIO_PIN   // Bitmask to set the data out pin
   #define ws2812_mask_clr  LIGHT_WS2812_GPIO_PIN   // Bitmask to clear the data out pin
+#endif
+#ifdef LIGHT_WS2812_FSL
+  // This example is for Freescale family
+  #define ws2812_port_set ((uint32_t*)&LIGHT_WS2812_GPIO_PORT->PSOR)  // Address of the data port register to set the pin
+  #define ws2812_port_clr ((uint32_t*)&LIGHT_WS2812_GPIO_PORT->PCOR) // Address of the data port register to clear the pin
+
+  #define ws2812_mask_set  1u << 2u  // Bitmask to set the data out pin
+  #define ws2812_mask_clr  1u << 2u  // Bitmask to clear the data out pin
 #endif
 ///////////////////////////////////////////////////////////////////////
 // CPU clock speed


### PR DESCRIPTION
Support for freescale family microcontrollers was added and tests were done on the kw36z development card at 32 mhz, the data obtained in the corresponding markdown were added.