### PR TITLE
revise LGT8x timing

### DIFF
--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.c
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.c
@@ -95,7 +95,7 @@ void ws2812_sendarray(uint8_t *data,uint16_t datlen)
 #endif
 
 #define w_nop1  "nop      \n\t"
-#define w_nop2  "rjmp .+0 \n\t"
+#define w_nop2  "brid .+0 \n\t"
 #define w_nop4  w_nop2 w_nop2
 #define w_nop8  w_nop4 w_nop4
 #define w_nop16 w_nop8 w_nop8


### PR DESCRIPTION
different from Arduino implementation, AVR code runs same clocks
within ws2812_sendarray_mask() assembler loop because it uses OUT
instruction, not ST.

so simply replace RJMP instruction to BRID.
This instruction takes 2clocks on both AVR and LGT8x, so there is no
need to CPU-specific definition.