### PR TITLE
added support for XMC4500 (Cortex M3)

### DIFF
--- a/light_ws2812_ARM/light_ws2812_cortex.c
+++ b/light_ws2812_ARM/light_ws2812_cortex.c
@@ -44,7 +44,7 @@ void ws2812_sendarray(uint8_t *data,int datlen)
 			"		lsl %[dat],#24				\n\t"
 			"		movs %[ctr],#8				\n\t"
 			"ilop%=:							\n\t"
-			"		lsl %[dat], #1				\n\t"
+			"		lsls %[dat], #1				\n\t"
 			"		str %[maskhi], [%[set]]		\n\t"
 #if (w1&1)
 			ws2812_DEL1
@@ -79,7 +79,7 @@ void ws2812_sendarray(uint8_t *data,int datlen)
 #if (w2&16)
 			ws2812_DEL16
 #endif
-			"		sub %[ctr], #1				\n\t"
+			"		subs %[ctr], #1				\n\t"
 			"		str %[masklo], [%[clr]]		\n\t"
 			"		beq	end%=					\n\t"
 #if (w3&1)

--- a/light_ws2812_ARM/light_ws2812_cortex.c
+++ b/light_ws2812_ARM/light_ws2812_cortex.c
@@ -46,8 +46,9 @@ void ws2812_sendarray(uint8_t *data,int datlen)
 			"ilop%=:							\n\t"
 #ifdef LIGHT_WS2812_XMC4500
 			"		lsls %[dat], #1				\n\t"
-#endif
+#else
 			"		lsl %[dat], #1				\n\t"
+#endif
 			"		str %[maskhi], [%[set]]		\n\t"
 #if (w1&1)
 			ws2812_DEL1
@@ -84,8 +85,9 @@ void ws2812_sendarray(uint8_t *data,int datlen)
 #endif
 #ifdef LIGHT_WS2812_XMC4500
 			"		subs %[ctr], #1				\n\t"
-#endif
+#else
 			"		sub %[ctr], #1				\n\t"
+#endif
 			"		str %[masklo], [%[clr]]		\n\t"
 			"		beq	end%=					\n\t"
 #if (w3&1)

--- a/light_ws2812_ARM/light_ws2812_cortex.c
+++ b/light_ws2812_ARM/light_ws2812_cortex.c
@@ -44,7 +44,10 @@ void ws2812_sendarray(uint8_t *data,int datlen)
 			"		lsl %[dat],#24				\n\t"
 			"		movs %[ctr],#8				\n\t"
 			"ilop%=:							\n\t"
+#ifdef LIGHT_WS2812_XMC4500
 			"		lsls %[dat], #1				\n\t"
+#endif
+			"		lsl %[dat], #1				\n\t"
 			"		str %[maskhi], [%[set]]		\n\t"
 #if (w1&1)
 			ws2812_DEL1
@@ -79,7 +82,10 @@ void ws2812_sendarray(uint8_t *data,int datlen)
 #if (w2&16)
 			ws2812_DEL16
 #endif
+#ifdef LIGHT_WS2812_XMC4500
 			"		subs %[ctr], #1				\n\t"
+#endif
+			"		sub %[ctr], #1				\n\t"
 			"		str %[masklo], [%[clr]]		\n\t"
 			"		beq	end%=					\n\t"
 #if (w3&1)

--- a/light_ws2812_ARM/light_ws2812_cortex.h
+++ b/light_ws2812_ARM/light_ws2812_cortex.h
@@ -31,6 +31,11 @@
   #include <stdint.h>
   #define LIGHT_WS2812_GPIO_PIN 2
   #define LIGHT_WS2812_XMC4500
+#elif defined(LIGHT_WS2812_UC_XMC1100)
+  #include "xmc_gpio.h"
+  #include <stdint.h>
+  #define LIGHT_WS2812_GPIO_PIN 2
+  #define LIGHT_WS2812_XMC1100
 #else
 #error "Error: Please define WS2812_UC_XXXXX"
 #endif
@@ -67,6 +72,14 @@
   #define ws2812_mask_clr  (1 << LIGHT_WS2812_GPIO_PIN)		// Bitmask to clear the data out pin
 #endif
 #ifdef LIGHT_WS2812_XMC4500
+  // This example is for XMC family
+  #define ws2812_port_set  ( (uint32_t*)(&((XMC_GPIO_PORT_t *)PORT1_BASE)->OUT) ) // Address of the data port register to set the pin
+  #define ws2812_port_clr  ws2812_port_set                                        // Address of the data port register to clear the pin
+
+  #define ws2812_mask_set  (1 << LIGHT_WS2812_GPIO_PIN)  // Bitmask to set the data out pin
+  #define ws2812_mask_clr  (0 << LIGHT_WS2812_GPIO_PIN)  // Bitmask to clear the data out pin
+#endif
+#ifdef LIGHT_WS2812_XMC1100
   // This example is for XMC family
   #define ws2812_port_set  ( (uint32_t*)(&((XMC_GPIO_PORT_t *)PORT1_BASE)->OUT) ) // Address of the data port register to set the pin
   #define ws2812_port_clr  ws2812_port_set                                        // Address of the data port register to clear the pin

--- a/light_ws2812_ARM/light_ws2812_cortex.h
+++ b/light_ws2812_ARM/light_ws2812_cortex.h
@@ -23,9 +23,14 @@
   #include "stm32l0xx_hal.h"
   #define LIGHT_WS2812_STM32
 #elif defined(LIGHT_WS2812_UC_FSL)
-#include "fsl_port.h"
-#include "fsl_gpio.h"
-#define LIGHT_WS2812_FSL
+  #include "fsl_port.h"
+  #include "fsl_gpio.h"
+  #define LIGHT_WS2812_FSL
+#elif defined(LIGHT_WS2812_UC_XMC4500)
+  #include "xmc_gpio.h"
+  #include <stdint.h>
+  #define LIGHT_WS2812_GPIO_PIN 2
+  #define LIGHT_WS2812_XMC4500
 #else
 #error "Error: Please define WS2812_UC_XXXXX"
 #endif
@@ -60,6 +65,14 @@
 
   #define ws2812_mask_set  (1 << LIGHT_WS2812_GPIO_PIN)		// Bitmask to set the data out pin
   #define ws2812_mask_clr  (1 << LIGHT_WS2812_GPIO_PIN)		// Bitmask to clear the data out pin
+#endif
+#ifdef LIGHT_WS2812_XMC4500
+  // This example is for XMC family
+  #define ws2812_port_set  ( (uint32_t*)(&((XMC_GPIO_PORT_t *)PORT1_BASE)->OUT) ) // Address of the data port register to set the pin
+  #define ws2812_port_clr  ws2812_port_set                                        // Address of the data port register to clear the pin
+
+  #define ws2812_mask_set  (1 << LIGHT_WS2812_GPIO_PIN)  // Bitmask to set the data out pin
+  #define ws2812_mask_clr  (0 << LIGHT_WS2812_GPIO_PIN)  // Bitmask to clear the data out pin
 #endif
 ///////////////////////////////////////////////////////////////////////
 // CPU clock speed


### PR DESCRIPTION
Hi,

i have ported the library to work with the Infineon XMC4500 board. It is based on a ARM Cortex M3.
I had to change the ASM timing code in two places. I am not sure if this change will break the compatability to M0/M0+. Please let me know how what is needed, to merge my changes upstream.

Cheers Paul