### PR TITLE
Now builds on avr-gcc 5.4.0.

### DIFF
--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.c
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.c
@@ -124,7 +124,7 @@ void ws2812_sendarray(uint8_t *data,uint16_t datlen)
 
 void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
 {
-  // `maskhi` is 0x80 if P?7 is the DATA line to the LED string, 0x04 for P?2 etc.
+  // `maskhi` is 0x80 if P?7 is LED DATA
   uint8_t curbyte,ctr,masklo;
   uint8_t sreg_prev;
 #if __AVR_ARCH__ != 100  
@@ -133,31 +133,21 @@ void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
 
   ws2812_DDRREG |= maskhi; // Enable output
   
+  // `masklo` and `maskhi` are written to PORT? to drive the DATA line low or
+  // high (rather than setting or clearing the bit in PORT?)
   masklo	=~maskhi&ws2812_PORTREG;
-  // `masklo` becomes the value to write to the PORT? register in order to
-  // drive the DATA line low.
   maskhi |=        ws2812_PORTREG;
-  // `maskhi` becomes the value to write to the PORT? register in order to
-  // drive the DATA line high.  All other bits in the PORT? register are
-  // preserved by becoming part of the byte that is written here.
   
   sreg_prev=SREG;
 
-  // If we are not expected to support interrupts while driving the LED
-  // string..
 #ifdef interrupt_is_disabled
   cli();  
 #endif  
 
-  // Go through each byte that should be sent to the LED string..
   while (datlen--) {
     curbyte=*data++;
     
-#ifndef __GNUC__
-    asm volatile(
-#else
     __asm__ volatile(
-#endif
     "       ldi   %0,8  \n\t"
 #ifndef interrupt_is_disabled
     "       clt         \n\t"

--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.c
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.c
@@ -124,6 +124,7 @@ void ws2812_sendarray(uint8_t *data,uint16_t datlen)
 
 void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
 {
+  // `maskhi` is 0x80 if P?7 is the DATA line to the LED string, 0x04 for P?2 etc.
   uint8_t curbyte,ctr,masklo;
   uint8_t sreg_prev;
 #if __AVR_ARCH__ != 100  
@@ -133,17 +134,30 @@ void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
   ws2812_DDRREG |= maskhi; // Enable output
   
   masklo	=~maskhi&ws2812_PORTREG;
+  // `masklo` becomes the value to write to the PORT? register in order to
+  // drive the DATA line low.
   maskhi |=        ws2812_PORTREG;
+  // `maskhi` becomes the value to write to the PORT? register in order to
+  // drive the DATA line high.  All other bits in the PORT? register are
+  // preserved by becoming part of the byte that is written here.
   
   sreg_prev=SREG;
+
+  // If we are not expected to support interrupts while driving the LED
+  // string..
 #ifdef interrupt_is_disabled
   cli();  
 #endif  
 
+  // Go through each byte that should be sent to the LED string..
   while (datlen--) {
     curbyte=*data++;
     
+#ifndef __GNUC__
     asm volatile(
+#else
+    __asm__ volatile(
+#endif
     "       ldi   %0,8  \n\t"
 #ifndef interrupt_is_disabled
     "       clt         \n\t"


### PR DESCRIPTION
Hi Tim,

I had to replace `asm volatile` with `__asm__ volatile` to get it to build on avr-gcc.  I did also add a few comments as I was trying to understand the code better.  Please let me know if you want to separate the changes if you want one but not the other.

Cheers!