### PR TITLE
Make interrupt handling configurable

### DIFF
--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.c
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.c
@@ -17,10 +17,6 @@
 #include <avr/interrupt.h>
 #include <avr/io.h>
 #include <util/delay.h>
-
-// Normally ws2812_sendarray_mask() runs under disabled-interrupt condition,
-// undefine if you want to accept interrupts in that function.
-#define interrupt_is_disabled
  
 // Setleds for standard RGB 
 void inline ws2812_setleds(struct cRGB *ledarray, uint16_t leds)
@@ -113,7 +109,7 @@ void ws2812_sendarray(uint8_t *data,uint16_t datlen)
 #endif
 
 #define w_nop1  "nop      \n\t"
-#ifdef interrupt_is_disabled
+#if (ws2812_interrupt_handling)
 #define w_nop2  "brid .+0 \n\t"
 #else
 #define w_nop2  "brtc .+0 \n\t"
@@ -140,7 +136,7 @@ void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
   
   sreg_prev=SREG;
 
-#ifdef interrupt_is_disabled
+#if (ws2812_interrupt_handling)
   cli();  
 #endif  
 
@@ -149,7 +145,7 @@ void inline ws2812_sendarray_mask(uint8_t *data,uint16_t datlen,uint8_t maskhi)
     
     __asm__ volatile(
     "       ldi   %0,8  \n\t"
-#ifndef interrupt_is_disabled
+#if (ws2812_interrupt_handling)
     "       clt         \n\t"
 #endif
     "loop%=:            \n\t"
@@ -239,4 +235,9 @@ w_nop16
   }
   
   SREG=sreg_prev;
+
+#if (ws2812_interrupt_handling)
+  sei();  
+#endif
+
 }

--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.h
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.h
@@ -41,6 +41,18 @@
 #define ws2812_pin  0   // Data out pin
 #endif
 
+///////////////////////////////////////////////////////////////////////
+// Define interrupt behaviour
+//
+// Set to 1 if you want the library to handle interrupt toggling
+// (i.e. turning off interrupts when sending data and reverting back after).
+// Set to 0 if you need to allow interrupts (can introduce flickering!).
+//
+///////////////////////////////////////////////////////////////////////
+#if !defined(ws2812_interrupt_handling)
+#define ws2812_interrupt_handling  1
+#endif
+
 /*
  *  Structure of the LED array
  *

--- a/light_ws2812_AVR/Light_WS2812/ws2812_config.h
+++ b/light_ws2812_AVR/Light_WS2812/ws2812_config.h
@@ -31,4 +31,15 @@
 #define ws2812_port B     // Data port 
 #define ws2812_pin  0     // Data out pin
 
+///////////////////////////////////////////////////////////////////////
+// Define interrupt behaviour
+//
+// Set to 1 if you want the library to handle interrupt toggling
+// (i.e. turning off interrupts when sending data and reverting back after).
+// Set to 0 if you need to allow interrupts (can introduce flickering!).
+//
+///////////////////////////////////////////////////////////////////////
+
+#define ws2812_interrupt_handling 1
+
 #endif /* WS2812_CONFIG_H_ */


### PR DESCRIPTION
Put the macro to configure whether the library should handle interrupts inside the config header, to let users configure it more easily than to edit the library code.
Also when the macro is defined, the library turns the interrupts back on after turning them off before executing (was missing, probably a bug/oversight?).