### PR TITLE
Add extern C guards for AVR when using C++

### DIFF
--- a/light_apa102_AVR/Light_apa102/light_apa102.h
+++ b/light_apa102_AVR/Light_apa102/light_apa102.h
@@ -54,8 +54,18 @@ struct __attribute__ ((__packed__)) cRGB { uint8_t b; uint8_t g; uint8_t r; };  
  *         - Send out the LED data 
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 void apa102_setleds   	  		  (struct cRGB *ledarray, uint16_t number_of_leds);
 void apa102_setleds_brightness    (struct cRGB *ledarray, uint16_t number_of_leds,uint8_t brightness);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 /*
  * Internal defines

--- a/light_ws2812_AVR/Light_WS2812/light_ws2812.h
+++ b/light_ws2812_AVR/Light_WS2812/light_ws2812.h
@@ -63,7 +63,9 @@
 struct __attribute__ ((__packed__)) cRGB  { uint8_t g; uint8_t r; uint8_t b; };
 struct __attribute__ ((__packed__)) cRGBW { uint8_t g; uint8_t r; uint8_t b; uint8_t w;};
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* User Interface
  * 
@@ -91,6 +93,10 @@ void ws2812_setleds_rgbw(struct cRGBW *ledarray, uint16_t number_of_leds);
 
 void ws2812_sendarray     (uint8_t *array,uint16_t length);
 void ws2812_sendarray_mask(uint8_t *array,uint16_t length, uint8_t pinmask);
+
+#ifdef __cplusplus
+}
+#endif
 
 
 /*


### PR DESCRIPTION
The AVR implementations didn't have extern "C" guards so they would fail to compile in a C++ project.